### PR TITLE
Shader rendering

### DIFF
--- a/Quake 3 BSP Renderer.xcodeproj/project.pbxproj
+++ b/Quake 3 BSP Renderer.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		E27901F51B8D989C00E09E46 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = E27901F31B8D989C00E09E46 /* LaunchScreen.xib */; };
 		E279020B1B8D98CB00E09E46 /* BinaryReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E279020A1B8D98CB00E09E46 /* BinaryReader.swift */; };
 		E279020F1B8D9CAC00E09E46 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E279020E1B8D9CAC00E09E46 /* Shaders.metal */; };
+		E288A0991C81C3BD00A36DA8 /* Q3TextureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288A0981C81C3BD00A36DA8 /* Q3TextureLoader.swift */; };
 		E2C573761C6B64A9002004A2 /* Q3Shader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C573751C6B64A9002004A2 /* Q3Shader.swift */; };
 		E2C8CC851C40A93F003E0D4C /* BufferProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C8CC841C40A93F003E0D4C /* BufferProvider.swift */; };
 		E2E0B6191C2B9FB800365076 /* Bezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E0B6181C2B9FB800365076 /* Bezier.swift */; };
@@ -60,6 +61,7 @@
 		E27901FA1B8D989C00E09E46 /* Quake 3 BSP RendererTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Quake 3 BSP RendererTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E279020A1B8D98CB00E09E46 /* BinaryReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryReader.swift; sourceTree = "<group>"; };
 		E279020E1B8D9CAC00E09E46 /* Shaders.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
+		E288A0981C81C3BD00A36DA8 /* Q3TextureLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Q3TextureLoader.swift; sourceTree = "<group>"; };
 		E2C573751C6B64A9002004A2 /* Q3Shader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Q3Shader.swift; sourceTree = "<group>"; };
 		E2C8CC841C40A93F003E0D4C /* BufferProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BufferProvider.swift; sourceTree = "<group>"; };
 		E2E0B6181C2B9FB800365076 /* Bezier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bezier.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				E24F12B51C47C2D300DF1DCF /* Targa.swift */,
 				E2C573751C6B64A9002004A2 /* Q3Shader.swift */,
 				E2FB31041C6ED81500912E77 /* Q3ShaderParser.swift */,
+				E288A0981C81C3BD00A36DA8 /* Q3TextureLoader.swift */,
 			);
 			path = "Quake 3 BSP Renderer";
 			sourceTree = "<group>";
@@ -314,6 +317,7 @@
 			files = (
 				E2E0B6191C2B9FB800365076 /* Bezier.swift in Sources */,
 				E27901ED1B8D989C00E09E46 /* ViewController.swift in Sources */,
+				E288A0991C81C3BD00A36DA8 /* Q3TextureLoader.swift in Sources */,
 				E2C8CC851C40A93F003E0D4C /* BufferProvider.swift in Sources */,
 				E2FB31051C6ED81500912E77 /* Q3ShaderParser.swift in Sources */,
 				E24920C81C0733D100352118 /* Mesh.swift in Sources */,

--- a/Quake 3 BSP Renderer.xcodeproj/project.pbxproj
+++ b/Quake 3 BSP Renderer.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		E279020F1B8D9CAC00E09E46 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E279020E1B8D9CAC00E09E46 /* Shaders.metal */; };
 		E288A0991C81C3BD00A36DA8 /* Q3TextureLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288A0981C81C3BD00A36DA8 /* Q3TextureLoader.swift */; };
 		E2C573761C6B64A9002004A2 /* Q3Shader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C573751C6B64A9002004A2 /* Q3Shader.swift */; };
+		E2C7293D1C7C86CF0087A64A /* Material.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C7293C1C7C86CF0087A64A /* Material.swift */; };
 		E2C8CC851C40A93F003E0D4C /* BufferProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C8CC841C40A93F003E0D4C /* BufferProvider.swift */; };
 		E2E0B6191C2B9FB800365076 /* Bezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E0B6181C2B9FB800365076 /* Bezier.swift */; };
 		E2FB31051C6ED81500912E77 /* Q3ShaderParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FB31041C6ED81500912E77 /* Q3ShaderParser.swift */; };
@@ -63,6 +64,7 @@
 		E279020E1B8D9CAC00E09E46 /* Shaders.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
 		E288A0981C81C3BD00A36DA8 /* Q3TextureLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Q3TextureLoader.swift; sourceTree = "<group>"; };
 		E2C573751C6B64A9002004A2 /* Q3Shader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Q3Shader.swift; sourceTree = "<group>"; };
+		E2C7293C1C7C86CF0087A64A /* Material.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Material.swift; sourceTree = "<group>"; };
 		E2C8CC841C40A93F003E0D4C /* BufferProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BufferProvider.swift; sourceTree = "<group>"; };
 		E2E0B6181C2B9FB800365076 /* Bezier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bezier.swift; sourceTree = "<group>"; };
 		E2FB31041C6ED81500912E77 /* Q3ShaderParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Q3ShaderParser.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				E24F12B51C47C2D300DF1DCF /* Targa.swift */,
 				E2C573751C6B64A9002004A2 /* Q3Shader.swift */,
 				E2FB31041C6ED81500912E77 /* Q3ShaderParser.swift */,
+				E2C7293C1C7C86CF0087A64A /* Material.swift */,
 				E288A0981C81C3BD00A36DA8 /* Q3TextureLoader.swift */,
 			);
 			path = "Quake 3 BSP Renderer";
@@ -324,6 +327,7 @@
 				E2C573761C6B64A9002004A2 /* Q3Shader.swift in Sources */,
 				E2FB31071C6EDAA800912E77 /* NSScanner+Swift.swift in Sources */,
 				E21CCBB81C46297D00BF5B91 /* Q3ResourceLoader.swift in Sources */,
+				E2C7293D1C7C86CF0087A64A /* Material.swift in Sources */,
 				E24F12B61C47C2D300DF1DCF /* Targa.swift in Sources */,
 				E21CCBBC1C46344D00BF5B91 /* Q3Types.swift in Sources */,
 				E27901EB1B8D989C00E09E46 /* AppDelegate.swift in Sources */,

--- a/Quake 3 BSP Renderer/Material.swift
+++ b/Quake 3 BSP Renderer/Material.swift
@@ -69,6 +69,7 @@ struct Material {
             
             case .Lightmap:
                 pipelineDescriptor.fragmentFunction = lightmapFragmentFunction
+                texture = .Lightmap
                 
             default: break
             }

--- a/Quake 3 BSP Renderer/Material.swift
+++ b/Quake 3 BSP Renderer/Material.swift
@@ -25,6 +25,7 @@ struct Material {
     
     private struct MaterialStage {
         let pipelineState: MTLRenderPipelineState
+        let depthState: MTLDepthStencilState
         let texture: Material.StageTexture
     }
     
@@ -44,8 +45,9 @@ struct Material {
         let whiteTexture = textureLoader.loadWhiteTexture()
         
         for stage in shader.stages {
-            // Set up pipeline state
+            // Set up pipeline and depth state
             let pipelineDescriptor = MTLRenderPipelineDescriptor()
+            let stencilDescriptor = MTLDepthStencilDescriptor()
             
             pipelineDescriptor.vertexFunction = vertexFunction
             pipelineDescriptor.fragmentFunction = fragmentFunction
@@ -64,6 +66,10 @@ struct Material {
                 colorAttachment.destinationRGBBlendFactor = destinationBlend
                 colorAttachment.destinationAlphaBlendFactor = destinationBlend
             }
+            
+            stencilDescriptor.depthCompareFunction = .LessEqual
+            stencilDescriptor.depthWriteEnabled = stage.depthWrite
+            let depthState = device.newDepthStencilStateWithDescriptor(stencilDescriptor)
             
             var texture: Material.StageTexture = .Static(whiteTexture)
             
@@ -92,6 +98,7 @@ struct Material {
             stages.append(
                 MaterialStage(
                     pipelineState: pipelineState,
+                    depthState: depthState,
                     texture: texture
                 )
             )
@@ -103,8 +110,9 @@ struct Material {
         
         for stage in stages {
             
-            // Set pipeline state
+            // Set pipeline and depth state
             encoder.setRenderPipelineState(stage.pipelineState)
+            encoder.setDepthStencilState(stage.depthState)
             
             // Set the texture
             switch stage.texture {

--- a/Quake 3 BSP Renderer/Material.swift
+++ b/Quake 3 BSP Renderer/Material.swift
@@ -1,0 +1,131 @@
+//
+//  Material.swift
+//  Quake 3 BSP Renderer
+//
+//  Created by Thomas Brunoli on 23/02/2016.
+//  Copyright © 2016 Thomas Brunoli. All rights reserved.
+//
+
+import Foundation
+import MetalKit
+
+private let whiteTextureDescriptor = MTLTextureDescriptor.texture2DDescriptorWithPixelFormat(
+    .RGBA8Unorm,
+    width: 1,
+    height: 1,
+    mipmapped: false
+)
+
+struct Material {
+    private enum StageTexture {
+        case Static(MTLTexture)
+        case Animated(frequency: Float, Array<MTLTexture>)
+        case Lightmap
+    }
+    
+    private struct MaterialStage {
+        let pipelineState: MTLRenderPipelineState
+        let texture: Material.StageTexture
+    }
+    
+    private var textureLoader: Q3TextureLoader
+    private var stages: Array<MaterialStage> = []
+    private var cull: MTLCullMode
+    
+    init(shader: Q3Shader, device: MTLDevice, textureLoader: Q3TextureLoader) throws {
+        self.textureLoader = textureLoader
+        cull = shader.cull
+        
+        let library = device.newDefaultLibrary()!
+        let vertexFunction = library.newFunctionWithName("renderVert")
+        let fragmentFunction = library.newFunctionWithName("renderFrag")
+        let lightmapFragmentFunction = library.newFunctionWithName("renderFragLM")
+        
+        let whiteTexture = textureLoader.loadWhiteTexture()
+        
+        for stage in shader.stages {
+            // Set up pipeline state
+            let pipelineDescriptor = MTLRenderPipelineDescriptor()
+            
+            pipelineDescriptor.vertexFunction = vertexFunction
+            pipelineDescriptor.fragmentFunction = fragmentFunction
+            pipelineDescriptor.vertexDescriptor = MapMesh.vertexDescriptor()
+            pipelineDescriptor.sampleCount = 2
+            pipelineDescriptor.depthAttachmentPixelFormat = .Depth32Float
+            
+            let colorAttachment = pipelineDescriptor.colorAttachments[0]
+
+            colorAttachment.pixelFormat = .BGRA8Unorm
+            
+            if let (sourceBlend, destinationBlend) = stage.blending {
+                colorAttachment.blendingEnabled = true
+                colorAttachment.sourceRGBBlendFactor = sourceBlend
+                colorAttachment.sourceAlphaBlendFactor = sourceBlend
+                colorAttachment.destinationRGBBlendFactor = destinationBlend
+                colorAttachment.destinationAlphaBlendFactor = destinationBlend
+            }
+            
+            var texture: Material.StageTexture = .Static(whiteTexture)
+            
+            switch stage.map {
+            case .Texture(let path):
+                texture = .Static(textureLoader.loadTexture(path) ?? whiteTexture)
+                
+            case .TextureClamp(let path):
+                texture = .Static(textureLoader.loadTexture(path) ?? whiteTexture)
+                
+            case .Animated(let f, let paths):
+                let textures = paths.map { path in
+                    return textureLoader.loadTexture(path) ?? whiteTexture
+                }
+                
+                texture = .Animated(frequency: f, textures)
+            
+            case .Lightmap:
+                pipelineDescriptor.fragmentFunction = lightmapFragmentFunction
+                
+            default: break
+            }
+            
+            let pipelineState = try! device.newRenderPipelineStateWithDescriptor(pipelineDescriptor)
+            
+            stages.append(
+                MaterialStage(
+                    pipelineState: pipelineState,
+                    texture: texture
+                )
+            )
+        }
+    }
+    
+    func renderWithEncoder(encoder: MTLRenderCommandEncoder, time: Float, indexBuffer: MTLBuffer, indexCount: Int, lightmap: MTLTexture) {
+        encoder.setCullMode(.None)
+        
+        for stage in stages {
+            
+            // Set pipeline state
+            encoder.setRenderPipelineState(stage.pipelineState)
+            
+            // Set the texture
+            switch stage.texture {
+            case .Static(let texture):
+                encoder.setFragmentTexture(texture, atIndex: 0)
+                
+            case .Animated(let frequency, let textures):
+                let index = Int(time * frequency) % textures.count
+                encoder.setFragmentTexture(textures[index], atIndex: 0)
+            
+            case .Lightmap:
+                encoder.setFragmentTexture(lightmap, atIndex: 0)
+            }
+            
+            encoder.drawIndexedPrimitives(
+                .Triangle,
+                indexCount: indexCount,
+                indexType: .UInt32,
+                indexBuffer: indexBuffer,
+                indexBufferOffset: 0
+            )
+        }
+    }
+}

--- a/Quake 3 BSP Renderer/Mesh.swift
+++ b/Quake 3 BSP Renderer/Mesh.swift
@@ -123,12 +123,8 @@ class MapMesh {
         defaultTexture = textureLoader.loadWhiteTexture()
         
         for textureName in map.textureNames {
-            print("loading texture '\(textureName)'")
-            
             if let texture = textureLoader.loadTexture(textureName) {
                 self.textures[textureName] = texture
-            } else {
-                print("  Error loading \(textureName)")
             }
         }
     }

--- a/Quake 3 BSP Renderer/Mesh.swift
+++ b/Quake 3 BSP Renderer/Mesh.swift
@@ -30,8 +30,8 @@ struct FaceMesh {
     let indexCount: Int
     let indexBuffer: MTLBuffer
     
-    func renderWithEncoder(encoder: MTLRenderCommandEncoder) {
-        material.renderWithEncoder(encoder, time: 0, indexBuffer: indexBuffer, indexCount: indexCount, lightmap: lightmap)
+    func renderWithEncoder(encoder: MTLRenderCommandEncoder, time: Float) {
+        material.renderWithEncoder(encoder, time: time, indexBuffer: indexBuffer, indexCount: indexCount, lightmap: lightmap)
     }
 }
 
@@ -127,11 +127,11 @@ class MapMesh {
         }
     }
     
-    func renderWithEncoder(encoder: MTLRenderCommandEncoder) {
+    func renderWithEncoder(encoder: MTLRenderCommandEncoder, time: Float) {
         encoder.setVertexBuffer(vertexBuffer, offset: 0, atIndex: 0)
         
         for faceMesh in faceMeshes {
-            faceMesh.renderWithEncoder(encoder)
+            faceMesh.renderWithEncoder(encoder, time: time)
         }
     }
     

--- a/Quake 3 BSP Renderer/Q3ResourceLoader.swift
+++ b/Quake 3 BSP Renderer/Q3ResourceLoader.swift
@@ -47,8 +47,11 @@ class Q3ResourceLoader {
     
     // Loads the specified texture as a CGImage from the data file if it exists
     func loadTexture(path: String) -> UIImage? {
+        // This is to remove any extention from the path
+        let splitPath = path.characters.split{ $0 == "."}.map(String.init)
+        
         for fileType in ["jpg", "tga"] {
-            if let data = loadResource("\(path).\(fileType)") {
+            if let data = loadResource("\(splitPath[0]).\(fileType)") {
                 if fileType == "jpg" {
                     return UIImage(data: data)
                 } else if fileType == "tga" {

--- a/Quake 3 BSP Renderer/Q3Shader.swift
+++ b/Quake 3 BSP Renderer/Q3Shader.swift
@@ -171,7 +171,7 @@ struct Q3ShaderStage {
     var alphaGenerator: AlphaGenerator = .Identity
     var alphaFunction: AlphaFunction? = nil
     var textureCoordinateMods: Array<TextureCoordinateMod> = []
-    var depthFunction: DepthFunction = .LessThanOrEqual
+    var depthFunction: MTLCompareFunction = .LessEqual
     var depthWrite: Bool = true
 }
 

--- a/Quake 3 BSP Renderer/Q3Shader.swift
+++ b/Quake 3 BSP Renderer/Q3Shader.swift
@@ -85,15 +85,12 @@ enum TextureCoordinateMod {
     case Transform(m00: Float, m01: Float, m10: Float, m11: Float, t0: Float, t1: Float)
 }
 
-enum AlphaFunction {
-    case GT0
-    case LT128
-    case GE128
+enum AlphaFunction: UInt8 {
+    case GT0 = 0, LT128, GE128
 }
 
 enum DepthFunction {
-    case LessThanOrEqual
-    case Equal
+    case LessThanOrEqual, Equal
 }
 
 enum StageTexture {

--- a/Quake 3 BSP Renderer/Q3Shader.swift
+++ b/Quake 3 BSP Renderer/Q3Shader.swift
@@ -33,20 +33,6 @@ struct TurbulanceDescription {
     let frequency: Float
 }
 
-enum BlendMode {
-    case One
-    case Zero
-    case SourceColor
-    case SourceAlpha
-    case DestColor
-    case DestAlpha
-    case OneMinusSourceColor
-    case OneMinusSourceAlpha
-    case OneMinusDestColor
-    case OneMinusDestAlpha
-    case SourceAlphaSaturate
-}
-
 enum VertexDeform {
     case Wave(spread: Float, waveform: Waveform)
     case Normal(frequency: Float, amplitude: Float)

--- a/Quake 3 BSP Renderer/Q3Shader.swift
+++ b/Quake 3 BSP Renderer/Q3Shader.swift
@@ -179,7 +179,6 @@ struct Q3Shader {
     var name: String = ""
     var cull: MTLCullMode = .Front
     var sky: SkyParams? = nil
-    var blend: Bool = false
     var sort: Sort = .Opaque
     var vertexDeforms: Array<VertexDeform> = []
     var stages: Array<Q3ShaderStage> = []

--- a/Quake 3 BSP Renderer/Q3ShaderParser.swift
+++ b/Quake 3 BSP Renderer/Q3ShaderParser.swift
@@ -435,13 +435,15 @@ class Q3ShaderParser {
             case "portal": shader.sort = .Portal
                 
             case "sort": shader.sort = try readSort()
+            
+            case "nomipmap", "nomipmaps": shader.mipmapsEnabled = false
                 
             case "}": return shader
                 
             // Can ignore these safely
-            case "nopicmip", "nomipmap", "nomipmaps", "polygonoffset", "light1",
-                "entitymergable", "qer_nocarve", "q3map_globaltexture",
-                "lightning":
+            case
+                "nopicmip", "polygonoffset", "light1", "entitymergable",
+                "qer_nocarve", "q3map_globaltexture","lightning":
                 break
             
             case

--- a/Quake 3 BSP Renderer/Q3ShaderParser.swift
+++ b/Quake 3 BSP Renderer/Q3ShaderParser.swift
@@ -202,6 +202,7 @@ class Q3ShaderParser {
     
     func readStage() throws -> Q3ShaderStage {
         var stage = Q3ShaderStage()
+        var depthWriteOverride = false
         
         var token = try readString()
         
@@ -247,13 +248,17 @@ class Q3ShaderParser {
                 let depthFunc = try readString()
                 
                 switch depthFunc {
-                case "lequal": stage.depthFunction = .LessThanOrEqual
+                case "lequal": stage.depthFunction = .LessEqual
                 case "equal": stage.depthFunction = .Equal
                 default: throw Q3ShaderParserError.UnknownToken(depthFunc)
                 }
             
             case "blendfunc":
                 let blendfunc = try readString()
+                
+                if !depthWriteOverride {
+                    stage.depthWrite = false
+                }
                 
                 switch blendfunc.lowercaseString {
                 case "add", "gl_add":
@@ -324,7 +329,9 @@ class Q3ShaderParser {
             
             case "tcmod": stage.textureCoordinateMods.append(try readTextureCoordinateMod())
             
-            case "depthwrite": stage.depthWrite = true
+            case "depthwrite":
+                depthWriteOverride = true
+                stage.depthWrite = true
             
             case "detail": break
             

--- a/Quake 3 BSP Renderer/Q3TextureLoader.swift
+++ b/Quake 3 BSP Renderer/Q3TextureLoader.swift
@@ -1,0 +1,97 @@
+//
+//  Q3TextureLoader.swift
+//  Quake 3 BSP Renderer
+//
+//  Created by Thomas Brunoli on 27/02/2016.
+//  Copyright © 2016 Thomas Brunoli. All rights reserved.
+//
+
+import Foundation
+import MetalKit
+
+class Q3TextureLoader {
+    let loader: Q3ResourceLoader
+    let device: MTLDevice
+    
+    private let commandQueue: MTLCommandQueue
+    private let textureLoader: MTKTextureLoader
+    private var whiteTexture: MTLTexture? = nil
+    
+    private let lightmapDescriptor = MTLTextureDescriptor.texture2DDescriptorWithPixelFormat(
+        .RGBA8Unorm,
+        width: 128,
+        height: 128,
+        mipmapped: true
+    )
+    
+    init(loader: Q3ResourceLoader, device: MTLDevice) {
+        self.loader = loader
+        self.device = device
+        commandQueue = device.newCommandQueue()
+        textureLoader = MTKTextureLoader(device: device)
+    }
+    
+    func loadTexture(path: String) -> MTLTexture? {
+        guard let image = loader.loadTexture(path) else {
+            return nil
+        }
+        
+        let texture =  try! textureLoader.newTextureWithCGImage(image.CGImage!, options: [
+            MTKTextureLoaderOptionAllocateMipmaps: 1
+        ])
+        
+        generateMipmaps(texture)
+        
+        return texture
+    }
+    
+    func loadWhiteTexture() -> MTLTexture {
+        if let whiteTexture = self.whiteTexture {
+            return whiteTexture
+        }
+        
+        let descriptor = MTLTextureDescriptor.texture2DDescriptorWithPixelFormat(
+            .RGBA8Unorm,
+            width: 1,
+            height: 1,
+            mipmapped: false
+        )
+        
+        let whiteTexture = device.newTextureWithDescriptor(descriptor)
+        whiteTexture.replaceRegion(
+            MTLRegionMake2D(0, 0, 1, 1),
+            mipmapLevel: 0,
+            withBytes: [UInt8(255), UInt8(255), UInt8(255), UInt8(255)],
+            bytesPerRow: 4 * sizeof(UInt8)
+        )
+        
+        self.whiteTexture = whiteTexture
+        
+        return whiteTexture
+    }
+    
+    func loadLightmap(lightmap: Q3Lightmap) -> MTLTexture {
+        let texture = device.newTextureWithDescriptor(lightmapDescriptor)
+        
+        texture.replaceRegion(
+            MTLRegionMake2D(0, 0, 128, 128),
+            mipmapLevel: 0,
+            withBytes: lightmap,
+            bytesPerRow: 128 * 4 * sizeof(UInt8)
+        )
+        
+        generateMipmaps(texture)
+        
+        return texture
+    }
+    
+    private func generateMipmaps(texture: MTLTexture) {
+        let commandBuffer = commandQueue.commandBuffer()
+        let commandEncoder = commandBuffer.blitCommandEncoder()
+        
+        commandEncoder.generateMipmapsForTexture(texture)
+        
+        commandEncoder.endEncoding()
+        commandBuffer.commit()
+    }
+}

--- a/Quake 3 BSP Renderer/Q3TextureLoader.swift
+++ b/Quake 3 BSP Renderer/Q3TextureLoader.swift
@@ -89,40 +89,12 @@ class Q3TextureLoader {
             MTLRegionMake2D(0, 0, 128, 128),
             mipmapLevel: 0,
             withBytes: lightmap,
-            bytesPerRow: 128 * 4 * sizeof(UInt8)
+            bytesPerRow: 128 * 4
         )
         
         generateMipmaps(texture)
         
         return texture
-    }
-    
-    func loadAllShaderTextures(shaders: Array<Q3Shader>) -> Dictionary<String, MTLTexture> {
-        var textures: Dictionary<String, MTLTexture> = Dictionary()
-        
-        for shader in shaders {
-            for stage in shader.stages {
-                switch stage.map {
-                case .Texture(let name):
-                    if textures[name] != nil { continue }
-                    textures[name] = loadTexture(name) ?? loadWhiteTexture()
-
-                case .TextureClamp(let name):
-                    if textures[name] != nil { continue }
-                    textures[name] = loadTexture(name) ?? loadWhiteTexture()
-                
-                case .Animated(frequency: _, let names):
-                    for name in names {
-                        if textures[name] != nil { continue }
-                        textures[name] = loadTexture(name) ?? loadWhiteTexture()
-                    }
-                    
-                default: break
-                }
-            }
-        }
-        
-        return textures
     }
     
     private func generateMipmaps(texture: MTLTexture) {

--- a/Quake 3 BSP Renderer/Shaders.metal
+++ b/Quake 3 BSP Renderer/Shaders.metal
@@ -50,8 +50,7 @@ vertex VertexOut renderVert(VertexIn in [[stage_in]],
 }
 
 fragment half4 renderFrag(VertexOut vert [[stage_in]],
-                          texture2d<half> tex [[texture(0)]],
-                          texture2d<half> lm [[texture(1)]])
+                          texture2d<half> tex [[texture(0)]])
 {
     constexpr sampler s(coord::normalized,
                         address::repeat,
@@ -59,8 +58,16 @@ fragment half4 renderFrag(VertexOut vert [[stage_in]],
                         mip_filter::linear);
     constexpr float2 x = float2(1, 1);
     
-    half4 diffuseColor = tex.sample(s, x - vert.textureCoord);
-    half4 lightColor = lm.sample(s, vert.lightMapCoord);
+    return tex.sample(s, x - vert.textureCoord);
+}
+
+fragment half4 renderFragLM(VertexOut vert [[stage_in]],
+                            texture2d<half> lm [[texture(0)]])
+{
+    constexpr sampler s(coord::normalized,
+                        address::repeat,
+                        filter::linear,
+                        mip_filter::linear);
     
-    return diffuseColor * lightColor;
+    return lm.sample(s, vert.lightMapCoord);
 }

--- a/Quake 3 BSP Renderer/Shaders.metal
+++ b/Quake 3 BSP Renderer/Shaders.metal
@@ -55,12 +55,12 @@ fragment half4 renderFrag(VertexOut vert [[stage_in]],
 {
     constexpr float2 x = float2(1, 1);
     
-    return tex.sample(smp, x - vert.textureCoord);
+    return half4(vert.color) * tex.sample(smp, x - vert.textureCoord);
 }
 
 fragment half4 renderFragLM(VertexOut vert [[stage_in]],
                             texture2d<half> lm [[texture(0)]],
                             sampler smp [[sampler(0)]])
 {
-    return lm.sample(smp, vert.lightMapCoord);
+    return half4(vert.color) * lm.sample(smp, vert.lightMapCoord);
 }

--- a/Quake 3 BSP Renderer/Shaders.metal
+++ b/Quake 3 BSP Renderer/Shaders.metal
@@ -50,24 +50,17 @@ vertex VertexOut renderVert(VertexIn in [[stage_in]],
 }
 
 fragment half4 renderFrag(VertexOut vert [[stage_in]],
-                          texture2d<half> tex [[texture(0)]])
+                          texture2d<half> tex [[texture(0)]],
+                          sampler smp [[sampler(0)]])
 {
-    constexpr sampler s(coord::normalized,
-                        address::repeat,
-                        filter::linear,
-                        mip_filter::linear);
     constexpr float2 x = float2(1, 1);
     
-    return tex.sample(s, x - vert.textureCoord);
+    return tex.sample(smp, x - vert.textureCoord);
 }
 
 fragment half4 renderFragLM(VertexOut vert [[stage_in]],
-                            texture2d<half> lm [[texture(0)]])
+                            texture2d<half> lm [[texture(0)]],
+                            sampler smp [[sampler(0)]])
 {
-    constexpr sampler s(coord::normalized,
-                        address::repeat,
-                        filter::linear,
-                        mip_filter::linear);
-    
-    return lm.sample(s, vert.lightMapCoord);
+    return lm.sample(smp, vert.lightMapCoord);
 }

--- a/Quake 3 BSP Renderer/ViewController.swift
+++ b/Quake 3 BSP Renderer/ViewController.swift
@@ -88,21 +88,8 @@ class ViewController: UIViewController {
             height: Int(self.view.frame.height),
             mipmapped: false
         )
-        depthTextureDescriptor.textureType = .Type2DMultisample
-        depthTextureDescriptor.sampleCount = sampleCount
+        depthTextureDescriptor.textureType = .Type2D
         depthTexture = device.newTextureWithDescriptor(depthTextureDescriptor)
-        
-        // MSAA
-        let msaaDescriptor = MTLTextureDescriptor.texture2DDescriptorWithPixelFormat(
-            .BGRA8Unorm,
-            width: Int(self.view.frame.width),
-            height: Int(self.view.frame.height),
-            mipmapped: false
-        )
-        
-        msaaDescriptor.textureType = .Type2DMultisample
-        msaaDescriptor.sampleCount = sampleCount
-        msaaTexture = device.newTextureWithDescriptor(msaaDescriptor)
     }
     
     func draw() {
@@ -119,12 +106,9 @@ class ViewController: UIViewController {
             
             // Render Pass Descriptor
             let renderPassDescriptor = MTLRenderPassDescriptor()
-            renderPassDescriptor.colorAttachments[0].texture = msaaTexture
-            renderPassDescriptor.colorAttachments[0].resolveTexture = drawable.texture
-            renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0.8, 0.3, 0.2, 1)
+            renderPassDescriptor.colorAttachments[0].texture = drawable.texture
             renderPassDescriptor.colorAttachments[0].loadAction = .Clear
-            renderPassDescriptor.colorAttachments[0].storeAction = .MultisampleResolve
-            
+            renderPassDescriptor.colorAttachments[0].storeAction = .DontCare
             
             renderPassDescriptor.depthAttachment.texture = depthTexture
             renderPassDescriptor.depthAttachment.loadAction = .Clear

--- a/Quake 3 BSP Renderer/ViewController.swift
+++ b/Quake 3 BSP Renderer/ViewController.swift
@@ -173,7 +173,7 @@ class ViewController: UIViewController {
             commandEncoder.setRenderPipelineState(pipeline)
             commandEncoder.setVertexBuffer(uniformBuffer, offset: 0, atIndex: 1)
 
-            mapMesh.renderWithEncoder(commandEncoder)
+            mapMesh.renderWithEncoder(commandEncoder, time: Float(timer.timestamp))
 
             commandEncoder.endEncoding()
             


### PR DESCRIPTION
Adds the concept of a 'material' that manages the metal render pipeline, depth stencil, sampler and texture states. Also added a new texture loading mechanism, animated texture support, and early quake shader translation.

Next up will be generating metal shaders based upon the quake shader stages.

Closes #7 & #8
